### PR TITLE
BUG: 오늘 날짜의 가장 최근 로그 누락으로 표시되는 버그 수정

### DIFF
--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -279,12 +279,12 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
 
   // 금 월의 오늘 로그 추가하기
   const insertTodayLogs = (data: LogsData) => {
-    logsContainer.value.map((monthlog) => {
+    logsContainer.value.forEach((monthlog) => {
       if (
         monthlog.date ===
         `${today.value.getFullYear()}. ${today.value.getMonth() + 1}`
       ) {
-        monthlog.logs.inOutLogs.push(...data.inOutLogs);
+        monthlog.logs.inOutLogs.unshift(...data.inOutLogs);
         return;
       }
     });


### PR DESCRIPTION
오늘 날짜로 입실했을 경우, 누락으로 표시되는 버그가 있었습니다.

현재 입실 중인 경우에는 누락 대신 `-` 로 표시되도록 수정하였습니다.