### PR TITLE
BUG: 모바일 캘린더뷰 새로고침시 api 요청실패 버그 처리

### DIFF
--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -9,7 +9,7 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
   const today = ref(new Date());
 
   const getStorageYear = () => {
-    if (getStorage("showDate")) {
+    if (getStorage("showDate", "year")) {
       return getStorage("showDate", "year");
     }
     return today.value.getFullYear();
@@ -19,7 +19,7 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
   const year = ref(getStorageYear());
 
   const getStorageMonth = () => {
-    if (getStorage("showDate")) {
+    if (getStorage("showDate", "month")) {
       return getStorage("showDate", "month");
     }
     return today.value.getMonth();
@@ -33,7 +33,7 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
   const lastDate = ref(new Date(year.value, month.value + 1, 0).getDate());
 
   const getStorageDate = () => {
-    if (getStorage("showDate")) {
+    if (getStorage("showDate", "date")) {
       return getStorage("showDate", "date");
     }
     return today.value.getDate();

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -6,6 +6,7 @@ import LogTable from "@/components/calendar/LogTable.vue";
 import LoadingAnimation from "@/components/common/LoadingAnimation.vue";
 import { useMonthLogStore } from "@/stores/monthlog";
 import { onMounted, ref, watch } from "vue";
+import { getStorage } from "@/utils/localStorage";
 
 const monthLog = useMonthLogStore();
 const {
@@ -23,6 +24,9 @@ const {
 
 onMounted(() => {
   apiLogsMonthData();
+  if (!getStorage("showDate", "date")) {
+    setSelectedDate(new Date().getDate());
+  }
 });
 
 const clickDate = (date: number) => {


### PR DESCRIPTION
로그인 하자마자 캘린더뷰로 바로 들어간 후, 새로고침을 하게되면 팅기는 버그가 있었습니다.
해당 문제를 위해서 처음 캘린더 들어온 경우엔 localstorage에 오늘 날짜의 Date로 저장을 하는 코드를 추가 했습니다.