### PR TITLE
FIX: 월 리스트 개수와 로그 컨테이너의 개수가 같은지 확인하는 함수 추가 #58

### DIFF
--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -177,9 +177,16 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     logs: LogsData;
   }
 
+  // 월 리스트 개수와 로컬스토리지에 저장된 로그 컨테이너 개수가 같은지 확인
+  const checkOptions = () => {
+    const data: logsContainer[] = getStorage("logsContainer");
+    if (data.length === monthList.value.length) return true;
+    return false;
+  };
+
   // 월 로그 컨테이너 세팅
   const setLogsContainer = () => {
-    if (getStorage("logsContainer")) {
+    if (checkOptions()) {
       const data: logsContainer[] = getStorage("logsContainer");
       return data;
     }


### PR DESCRIPTION
이전에 로컬스토리지에 값이 존재하는지 여부만 체크하는 코드에서 월 리스트와 로그컨테이너의 개수가 같은지 여부를 확인하여 같은 경우에만 스토리지에서 가지고 오는 방식으로 변경하였습니다.
이번 달이 바뀌는 경우, 로그 컨테이너도 리셋되는 방식으로 코드를 변경해보았습니다.