### PR TITLE
월이 바뀐 경우, 로그가 안보이는 버그 해결 #58

### DIFF
--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -177,9 +177,16 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     logs: LogsData;
   }
 
+  // 월 리스트 개수와 로컬스토리지에 저장된 로그 컨테이너 개수가 같은지 확인
+  const checkOptions = () => {
+    const data: logsContainer[] = getStorage("logsContainer");
+    if (data.length === monthList.value.length) return true;
+    return false;
+  };
+
   // 월 로그 컨테이너 세팅
   const setLogsContainer = () => {
-    if (getStorage("logsContainer")) {
+    if (checkOptions()) {
       const data: logsContainer[] = getStorage("logsContainer");
       return data;
     }

--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -279,29 +279,12 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     insertTodayLogs(logsData);
   };
 
-  const checkNowMonth = () => {
-    if (showMonth() === today.value.getMonth()) {
-      return true;
-    }
-    return false;
-  };
-
-  const checkHasLogs = () => {
-    if (
-      logsContainer.value.find(
-        (log) => log.date === `${showYear()}. ${showMonth() + 1}`
-      )?.logs.inOutLogs.length !== 0
-    ) {
-      return true;
-    }
-    return false;
-  };
-
   // 지난 달이고 업데이트 날짜가 이번 달 이상이면 true 데이터 호출 안함.
   const checkPrevMonthUpdateAt = () => {
     const updatedAt = logsContainer.value.find(
       (log) => log.date === `${showYear()}. ${showMonth() + 1}`
     )?.updatedAt;
+    console.log(updatedAt);
     if (updatedAt) {
       const date = new Date(updatedAt);
       if (date.getFullYear() > showYear() || date.getMonth() > showMonth()) {
@@ -311,35 +294,9 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     return false;
   };
 
-  // 이번 달이고 오늘 날짜면 true -> apiTodayData 호출
-  const checkNowMonthUpdateAt = () => {
-    const updatedAt = logsContainer.value.find(
-      (log) => log.date === `${showYear()}. ${showMonth() + 1}`
-    )?.updatedAt;
-    if (updatedAt) {
-      const date = new Date(updatedAt);
-      if (
-        date.getMonth() === today.value.getMonth() &&
-        date.getDate() === today.value.getDate()
-      ) {
-        return true;
-      }
-    }
-    return false;
-  };
-
   // 월 로그 api 호출
   const apiLogsMonthData = async () => {
-    if (checkHasLogs()) {
-      if (checkNowMonth()) {
-        if (checkNowMonthUpdateAt()) {
-          apiTodayData();
-          return;
-        }
-      } else {
-        if (checkPrevMonthUpdateAt()) return;
-      }
-    }
+    if (checkPrevMonthUpdateAt()) return;
     isLoading.value = true;
     try {
       const { data: monthData } = await getLogsmonth(


### PR DESCRIPTION
월 리스트 개수와 로그 컨테이너의 개수가 불일치하여 발생하는 버그였습니다.
해당 개수가 다른 경우를 체크하여 로그 컨테이너를 새롭게 갱신하는 방식으로 코드를 변경해 처리해보았습니다.