### PR TITLE
iOS 주소표시줄 위치에 따른 하단 메뉴바 크기 조절 #61

### DIFF
--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -46,12 +46,20 @@ const { resetSelectedDate } = monthLog;
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 50px;
   background-color: var(--color-background);
   filter: var(--menu-shadow);
   z-index: 9;
   padding: 0 30px;
   user-select: none;
+  box-sizing: border-box;
+}
+
+.wrap::after {
+  content: "";
+  display: block;
+  background-color: var(--color-background);
+  height: env(safe-area-inset-bottom);
+  overflow: hidden;
 }
 
 @media (min-width: 425px) {
@@ -66,7 +74,7 @@ nav {
   display: flex;
   justify-content: space-around;
   align-items: center;
-  height: 100%;
+  height: 50px;
 }
 nav a {
   display: block;


### PR DESCRIPTION
메뉴바 after에 height: env(safe-area-inset-bottom); 를 사용하여 메뉴바가 없는 경우 추가적인 높이를 주는 방식으로 구현해보았습니다.