### PR TITLE
[FE] FEAT: v3 버전 업데이트 #75

### DIFF
--- a/src/api/logsAPI.ts
+++ b/src/api/logsAPI.ts
@@ -12,7 +12,7 @@ export const getLogsDate = async (year: number, month: number, day: number) => {
   return response;
 };
 
-const getLogsMonthURL = "v2/tag-log/getAllTagPerMonth";
+const getLogsMonthURL = "v3/tag-log/getAllTagPerMonth";
 export const getLogsmonth = async (year: number, month: number) => {
   const response = await instance.get(getLogsMonthURL, {
     params: {

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -6,13 +6,13 @@ export const getIsLogin = async () => {
   return response;
 };
 
-const mainInfoURL = "v2/tag-log/maininfo";
+const mainInfoURL = "v3/tag-log/maininfo";
 export const getMainInfo = async () => {
   const response = await instance.get(mainInfoURL);
   return response;
 };
 
-const accTimesURL = "v2/tag-log/accumulationTimes";
+const accTimesURL = "v3/tag-log/accumulationTimes";
 export const getAccTimes = async () => {
   const response = await instance.get(accTimesURL);
   return response;

--- a/src/components/calendar/AccMonth.vue
+++ b/src/components/calendar/AccMonth.vue
@@ -37,6 +37,7 @@ watch(showLogs, () => {
   font-weight: 700;
   box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.25);
   transition: border 0.2s ease-in-out;
+  cursor: pointer;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/calendar/AccMonth.vue
+++ b/src/components/calendar/AccMonth.vue
@@ -1,17 +1,26 @@
 <script setup lang="ts">
 import { useMonthLogStore } from "@/stores/monthlog";
 import { ref, watch } from "vue";
-const { getMonthAccTimeText, showLogs } = useMonthLogStore();
+const { getMonthAccTimeText, getMonthAcceptedTimeText, showLogs } =
+  useMonthLogStore();
 
 const monthText = ref(getMonthAccTimeText());
+const acceptedMonthText = ref(getMonthAcceptedTimeText());
+const isClicked = ref(false);
 
 watch(showLogs, () => {
   monthText.value = getMonthAccTimeText();
+  acceptedMonthText.value = getMonthAcceptedTimeText();
 });
 </script>
 
 <template>
-  <div class="month">총 {{ monthText.hour }}시간 {{ monthText.minute }}분</div>
+  <div v-if="!isClicked" @click="isClicked = !isClicked" class="month">
+    총 {{ monthText.hour }}시간 {{ monthText.minute }}분
+  </div>
+  <div v-else @click="isClicked = !isClicked" class="month acceptTime">
+    인정 시간 {{ acceptedMonthText.hour }}시간 {{ acceptedMonthText.minute }}분
+  </div>
 </template>
 
 <style scoped>
@@ -26,6 +35,18 @@ watch(showLogs, () => {
   border-radius: 10px;
   font-size: 0.875rem;
   font-weight: 700;
-  border: 2px solid #fff;
+  box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.25);
+  transition: border 0.2s ease-in-out;
+}
+
+@media (prefers-color-scheme: dark) {
+  .month {
+    border: 2px solid #fff;
+  }
+}
+
+.acceptTime {
+  background-color: var(--color-primary);
+  box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.25) inset;
 }
 </style>

--- a/src/components/common/DefaultModal.vue
+++ b/src/components/common/DefaultModal.vue
@@ -36,7 +36,6 @@
   transform: translate(-50%, -50%);
   width: 80%;
   max-width: 300px;
-  min-height: 300px;
   background-color: var(--white);
   border-radius: 20px;
   padding: 50px 40px 30px;
@@ -59,5 +58,9 @@ p {
   color: var(--color-primary);
   font-weight: 700;
   text-align: center;
+}
+
+.buttons {
+  margin-top: 40px;
 }
 </style>

--- a/src/components/home/FoldCardCompact.vue
+++ b/src/components/home/FoldCardCompact.vue
@@ -1,81 +1,36 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 import ChevronIcon from "@/components/icons/IconChevron.vue";
-import CircleProgress from "@/components/home/CircleProgress.vue";
 import LoadingAnimationVue from "@/components/common/LoadingAnimation.vue";
 import { useMonthLogStore } from "@/stores/monthlog";
-import { useHomeStore } from "@/stores/home";
 
 const props = defineProps<{
   hour: number;
   min: number;
-  isMonth?: boolean;
+  acceptedHour: number;
+  acceptedMin: number;
 }>();
-
-const { getGoalDateHour, getGoalMonthHour, setGoalDateHour, setGoalMonthHour } =
-  useHomeStore();
 
 const monthStore = useMonthLogStore();
 const { showIsLoading } = monthStore;
 const isLoading = ref(showIsLoading());
 
 const isOpen = ref(false);
-const goalTimeSet = () => {
-  if (props.isMonth) {
-    return Number(getGoalMonthHour());
-  } else {
-    return Number(getGoalDateHour());
-  }
-};
-
-const goalTime = ref(goalTimeSet());
-const colorSet = ref(props.isMonth);
 
 watch(showIsLoading, (val) => {
   isLoading.value = val;
 });
 
-watch(goalTime, (val) => {
-  if (props.isMonth) {
-    setGoalMonthHour(Number(val));
-  } else {
-    setGoalDateHour(Number(val));
-  }
-});
-
-const culculatePercent = () => {
-  if (goalTime.value === 0) return 0;
-  return Math.round(((props.hour + props.min / 60) / goalTime.value) * 100);
-};
-
-const clickHandler = () => {
-  isOpen.value = !isOpen.value;
-  if (isOpen.value) {
-    colorSet.value = false;
-  } else {
-    colorSet.value = props.isMonth;
-  }
-};
-
 const checkColor = () => {
-  if (colorSet.value) {
+  if (!isOpen.value) {
     return "#ffffff";
   }
 };
-
-const dayOptions = [
-  4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-];
-
-const monthOptions = [
-  80, 100, 120, 140, 160, 180, 200, 220, 240, 260, 280, 300, 320, 340, 360, 380,
-  400, 420,
-];
 </script>
 
 <template>
-  <div class="wrap" :class="{ on: isOpen, primaryColor: colorSet }">
-    <div class="textWrap use tapHighlight" @click="clickHandler">
+  <div class="wrap" :class="{ on: isOpen, primaryColor: !isOpen }">
+    <div class="textWrap use tapHighlight" @click="isOpen = !isOpen">
       <h2>
         <slot name="title"></slot>
       </h2>
@@ -95,32 +50,21 @@ const monthOptions = [
       </div>
     </div>
     <div class="textWrap goal" :class="{ on: isOpen }">
-      <h2>목표 시간</h2>
-      <div>
-        <select v-if="!isMonth" v-model="goalTime" class="timeNumber select">
-          <option
-            v-for="index in dayOptions"
-            :key="index"
-            :value="index"
-            :selected="index === 12"
-          >
-            {{ index }}
-          </option>
-        </select>
-        <select v-else v-model="goalTime" class="timeNumber select">
-          <option
-            v-for="index in monthOptions"
-            :key="index"
-            :value="index"
-            :selected="index === 80"
-          >
-            {{ index }}
-          </option>
-        </select>
-        <span class="timeUnit">시간</span>
+      <h2>
+        <slot name="title2"></slot>
+      </h2>
+      <div v-if="isLoading" class="loading"><LoadingAnimationVue /></div>
+      <div v-else>
+        <span class="timeNumber">
+          {{ props.acceptedHour }}
+        </span>
+        <span class="timeUnit">시간{{ " " }}</span>
+        <span class="timeNumber">
+          {{ props.acceptedMin }}
+        </span>
+        <span class="timeUnit">분</span>
       </div>
     </div>
-    <CircleProgress :isOpen="isOpen" :percent="culculatePercent()" />
   </div>
 </template>
 
@@ -139,7 +83,7 @@ const monthOptions = [
 }
 
 .wrap.on {
-  height: 260px;
+  height: 120px;
 }
 
 .wrap.primaryColor {
@@ -169,8 +113,7 @@ const monthOptions = [
 
 .textWrap.goal {
   margin-top: 60px;
-  margin-left: 18px;
-  margin-right: 20px;
+  margin-right: 18px;
   transition: all 0.3s ease-in-out;
   opacity: 0;
 }
@@ -201,28 +144,6 @@ h2 {
   font-weight: 700;
   line-height: 1.5rem;
   color: var(--black);
-}
-
-.goal .timeNumber {
-  width: 60px;
-  height: 30px;
-  border: none;
-  text-align: right;
-  padding-right: 5px;
-  font-size: 1.25rem;
-  font-weight: 700;
-  font-family: Inter, sans-serif;
-  color: var(--black);
-}
-
-.select {
-  direction: rtl;
-  cursor: pointer;
-  -o-appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: transparent;
 }
 
 .timeUnit {

--- a/src/components/home/FoldCardCompact.vue
+++ b/src/components/home/FoldCardCompact.vue
@@ -49,7 +49,7 @@ const checkColor = () => {
         </div>
       </div>
     </div>
-    <div class="textWrap goal" :class="{ on: isOpen }">
+    <div class="textWrap accepted" :class="{ on: isOpen }">
       <h2>
         <slot name="title2"></slot>
       </h2>
@@ -111,14 +111,14 @@ const checkColor = () => {
   padding: 0;
 }
 
-.textWrap.goal {
+.textWrap.accepted {
   margin-top: 60px;
   margin-right: 18px;
   transition: all 0.3s ease-in-out;
   opacity: 0;
 }
 
-.textWrap.goal.on {
+.textWrap.accepted.on {
   margin-top: 16px;
   opacity: 1;
 }
@@ -151,6 +151,12 @@ h2 {
   font-weight: 600;
   line-height: 1.5rem;
   color: var(--black);
+}
+
+.accepted h2,
+.accepted .timeUnit,
+.accepted .timeNumber {
+  color: var(--color-primary);
 }
 
 .vIcon {

--- a/src/components/home/UserNumSection.vue
+++ b/src/components/home/UserNumSection.vue
@@ -15,10 +15,7 @@ const props = defineProps<{
     <h2 :class="{ online: props.isOnline }">실시간 현황</h2>
     <div class="userNumCards">
       <UserNumCard class="m-8" :userNum="props.numberOfPeople.gaepo ?? 0">
-        <template #title>개포</template>
-      </UserNumCard>
-      <UserNumCard class="m-8" :userNum="props.numberOfPeople.seocho ?? 0">
-        <template #title>서초</template>
+        <template #title>서울</template>
       </UserNumCard>
     </div>
   </section>

--- a/src/components/icons/IconExclamationMark.vue
+++ b/src/components/icons/IconExclamationMark.vue
@@ -1,0 +1,29 @@
+<template>
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M7.99992 14.6663C11.6666 14.6663 14.6666 11.6663 14.6666 7.99967C14.6666 4.33301 11.6666 1.33301 7.99992 1.33301C4.33325 1.33301 1.33325 4.33301 1.33325 7.99967C1.33325 11.6663 4.33325 14.6663 7.99992 14.6663Z"
+      stroke="#9B9797"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M8 5.33301V8.66634"
+      stroke="#9B9797"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M7.99634 10.667H8.00233"
+      stroke="#9B9797"
+      stroke-width="1.33333"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -35,7 +35,6 @@ export const useHomeStore = defineStore("home", () => {
 
   const numberOfPeople = ref({
     gaepo: 0,
-    seocho: 0,
   });
 
   const infoMessages = ref({
@@ -168,7 +167,6 @@ export const useHomeStore = defineStore("home", () => {
   };
 
   const getInfoMessages = () => {
-    console.log(infoMessages.value);
     return infoMessages.value;
   };
 
@@ -184,7 +182,6 @@ export const useHomeStore = defineStore("home", () => {
       };
       numberOfPeople.value = {
         gaepo: mainInfo.gaepo,
-        seocho: mainInfo.seocho,
       };
       infoMessages.value = mainInfo.infoMessages;
     } catch (error) {
@@ -198,9 +195,9 @@ export const useHomeStore = defineStore("home", () => {
     return { hour, minute };
   };
 
-  const calHours = (time: number) => {
-    const str = (time / 3600).toFixed(1);
-    return str;
+  const calcHours = (time: number) => {
+    const str = Math.floor((time / 3600) * 10) / 10;
+    return str.toString();
   };
 
   const calcWeely = (index: number) => {
@@ -232,14 +229,14 @@ export const useHomeStore = defineStore("home", () => {
       tempData = tempData.map((data, index) => {
         return {
           periods: calcWeely(index),
-          total: calHours(weeklyAccTime.value[index]),
+          total: calcHours(weeklyAccTime.value[index]),
         };
       });
     } else {
       tempData = dumyData.map((data, index) => {
         return {
           periods: calcWeely(index),
-          total: calHours(weeklyAccTime.value[index]),
+          total: calcHours(weeklyAccTime.value[index]),
         };
       });
     }
@@ -262,14 +259,14 @@ export const useHomeStore = defineStore("home", () => {
       tempData = tempData.map((data, index) => {
         return {
           periods: calcMonthly(index),
-          total: calHours(monthlyAccTime.value[index]),
+          total: calcHours(monthlyAccTime.value[index]),
         };
       });
     } else {
       tempData = dumyData.map((data, index) => {
         return {
           periods: calcMonthly(index),
-          total: calHours(monthlyAccTime.value[index]),
+          total: calcHours(monthlyAccTime.value[index]),
         };
       });
     }

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -115,9 +115,6 @@ export const useHomeStore = defineStore("home", () => {
         userInfo.value.tagAt!,
         accDate.value
       );
-      const targetTime = new Date(userInfo.value.tagAt!);
-      console.log(targetTime);
-      console.log(time);
       return time;
     }
 

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -27,8 +27,8 @@ export const useHomeStore = defineStore("home", () => {
     minute: 0,
   });
 
-  const goalDateHour = ref(getStorage("goalDateHour") || 4);
-  const goalMonthHour = ref(getStorage("goalMonthHour") || 80);
+  const goalDateHour = ref(getStorage("goalDateHour") || 12);
+  const goalMonthHour = ref(getStorage("goalMonthHour") || 160);
 
   const weeklyAccTime = ref([0, 0, 0, 0, 0, 0]);
   const monthlyAccTime = ref([0, 0, 0, 0, 0, 0]);

--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -299,7 +299,6 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     const updatedAt = logsContainer.value.find(
       (log) => log.date === `${showYear()}. ${showMonth() + 1}`
     )?.updatedAt;
-    console.log(updatedAt);
     if (updatedAt) {
       const date = new Date(updatedAt);
       if (date.getFullYear() > showYear() || date.getMonth() > showMonth()) {

--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -192,7 +192,13 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
       return data;
     }
     return monthList.value.map((option) => {
-      const data: LogsData = { login: "", profileImage: "", inOutLogs: [] };
+      const data: LogsData = {
+        login: "",
+        profileImage: "",
+        inOutLogs: [],
+        acceptedAccumulationTime: 0,
+        totalAccumulationTime: 0,
+      };
       return {
         date: option,
         updatedAt: "",
@@ -470,7 +476,7 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
   };
 
   // 선택된 월의 누적시간 계산
-  const getMonthAccTime = () => {
+  /* const getMonthAccTime = () => {
     let duration = 0;
     const logs = showLogs();
     if (!logs || logs.inOutLogs.length === 0) return duration;
@@ -485,17 +491,22 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
       }
     });
     return duration / 3600;
+  }; */
+
+  const calcSecToTime = (sec: number) => {
+    const hour = Math.floor(sec / 3600);
+    const minute = Math.floor((sec % 3600) / 60);
+    return { hour, minute };
   };
 
   // 선택된 월의 누적시간 텍스트
   const getMonthAccTimeText = () => {
-    const accTime = getMonthAccTime();
-    const hour = Math.floor(accTime);
-    const min = Math.floor((accTime - hour) * 60);
-    return {
-      hour: hour,
-      minute: min,
-    };
+    return calcSecToTime(showLogs()?.totalAccumulationTime as number);
+  };
+
+  // 선택된 월의 인정 시간 텍스트
+  const getMonthAcceptedTimeText = () => {
+    return calcSecToTime(showLogs()?.acceptedAccumulationTime as number);
   };
 
   // 오늘보다 과거인지 체크
@@ -545,6 +556,7 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     showSelectedDateText,
     getSelectedDateAccTimeText,
     getMonthAccTimeText,
+    getMonthAcceptedTimeText,
     getDateLogs,
     dateTitle,
     showDateTitle,

--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -293,7 +293,8 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
     insertTodayLogs(logsData);
   };
 
-  // 지난 달이고 업데이트 날짜가 이번 달 이상이면 true 데이터 호출 안함.
+  // 현재 보고있는 달의 업데이트 날짜가 현재 보고 있는 달보다 나중이면 true
+  // -> api 호출 안함
   const checkPrevMonthUpdateAt = () => {
     const updatedAt = logsContainer.value.find(
       (log) => log.date === `${showYear()}. ${showMonth() + 1}`

--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -366,9 +366,9 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
   const getDateBgColor = (date: number) => {
     const accTime = getDateAccTime(date);
     if (accTime == 0) return DATE_BG_COLOR[0];
-    if (accTime > 9) return DATE_BG_COLOR[4];
-    if (accTime > 6) return DATE_BG_COLOR[3];
-    if (accTime > 3) return DATE_BG_COLOR[2];
+    if (accTime > 12) return DATE_BG_COLOR[4];
+    if (accTime > 8) return DATE_BG_COLOR[3];
+    if (accTime > 4) return DATE_BG_COLOR[2];
     return DATE_BG_COLOR[1];
   };
 

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -8,5 +8,5 @@ export interface UserInfo {
 
 export interface MainInfo extends UserInfo {
   gaepo?: string;
-  seocho?: string;
+  infoMessages?: object[];
 }

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -8,6 +8,8 @@ export interface LogsData {
   login: string;
   profileImage: string;
   inOutLogs: InOutLog[];
+  acceptedAccumulationTime: number;
+  totalAccumulationTime: number;
 }
 
 // 일별 로그타임 계산

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "composite": true,
     "lib": [],
-    "types": ["node", "jsdom"]
+    "types": ["node", "jsdom"],
+    "ignoreDeprecations": "5.0"
   }
 }


### PR DESCRIPTION
#75 

**이용 시간일**
- 일 이용 시간 클러스터 IN 인 경우, 시간이 움직입니다.
  - 분 단위 카운트 됩니다.

- 목표시간
  - 기본값 4 -> 12h 변경
- 안내문 모달이 추가되었습니다.

**월 누적 시간**
- 목표 시간 삭제
- "인정 시간" 추가
- "인정 시간" 이름 클릭 시, 안내문 모달 뜹니다.

** 주간, 월간 그래프**
- 시간 값을 반올림 -> floor로 변경

**실시간 현황**
- 서초 삭제
- 개포 -> 서울로 명칭 변경

**달력**
- ‘일' 마다 인정 시간을 넘을 시, 캘린더 '일' 오른쪽 상단에 회색 인디케이터 추가
- 토글 버튼 형태로 "총 시간", "인정 시간"으로 값 변경 됨.