### PR TITLE
[FE] BUG: 프로덕트 환경에서 로그아웃 시 토큰 삭제가 안되는 버그 #86

### DIFF
--- a/src/api/cookie/cookies.ts
+++ b/src/api/cookie/cookies.ts
@@ -1,4 +1,5 @@
 const tokenName = import.meta.env.VITE_TOKEN;
+const domain = new URL(window.location.origin).hostname;
 
 export const getCookie = () => {
   return document.cookie
@@ -10,5 +11,5 @@ export const getCookie = () => {
 };
 
 export const removeCookie = (): void => {
-  document.cookie = `${tokenName}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  document.cookie = `${tokenName}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };


### PR DESCRIPTION
프로덕트 환경에서 로그아웃 시 토큰 삭제가 안되는 버그가 있었습니다.

로컬에서는 삭제가 잘 되었으나, 실제 서비스에서는 로그아웃버튼을 클릭해도 지워지지 않습니다.

기존에 토큰을 삭제하는 방법은 아래와 같습니다.

```ts
export const removeCookie = (): void => {
  document.cookie = `${tokenName}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
};
```

기본적으로 서브도메인을 포함한 쿠키를 제거할때는 해당 도메인명을 꼭 명시해줘야하며, 도메인 이외에도 쿠키를 구울때 path를 주었다면 path 경로까지 포함해야만 쿠키가 정상적으로 삭제가 됩니다.

```ts
export const removeCookie = (): void => {
  document.cookie = `${tokenName}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
};
```

로 수정해서 dev에서 확인 후, main으로 머지하겠습니다.