### PR TITLE
[FE] FIX: isLogin 기능 삭제 #90

### DIFF
--- a/src/api/baseAPI.ts
+++ b/src/api/baseAPI.ts
@@ -30,7 +30,6 @@ instance.interceptors.response.use(
       error.response?.status === STATUS_401_UNAUTHORIZED ||
       error.response?.status === undefined
     ) {
-      localStorage.removeItem("isLogin");
       removeCookie();
       clearStorage();
       window.location.href = "/";

--- a/src/api/cookie/cookies.ts
+++ b/src/api/cookie/cookies.ts
@@ -4,12 +4,14 @@ export const getCookie = () => {
   return document.cookie
     .split(";")
     .map((cookie) => cookie.trim())
-    .filter((cookie) => tokenName === cookie.split("=")[0])
-    .join("")
-    .split("=")[1];
+    .find((cookie) => cookie.startsWith(`${tokenName}=`))
+    ?.split("=")[1];
 };
 
 export const removeCookie = (): void => {
-  const domain = ".24hoursarenotenough.42seoul.kr";
+  const hostname = window.location.hostname;
+  const domain =
+    hostname === "localhost" ? "" : ".24hoursarenotenough.42seoul.kr";
+
   document.cookie = `${tokenName}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };

--- a/src/views/AuthView.vue
+++ b/src/views/AuthView.vue
@@ -11,7 +11,6 @@ onMounted(() => {
   setTimeout(async () => {
     const isLogin = await getIsLogin();
     if (isLogin?.status === STATUS_204_NO_CONTENT) {
-      localStorage.setItem("isLogin", "true");
       router.push("/home");
     } else {
       router.push("/");


### PR DESCRIPTION
#90 

간헐적으로 accessToken은 만들어지나 백엔드에서 리다이렉션이 제대로 안되고, 500에러가 뜨는 상황이 있습니다.

그 상황에서 /auth 로 리다이렉션이 안되기 때문에, 다시 login으로 온 경우 유효한 토큰을 들고 있다면 /home 으로 가도록 설정했습니다.

이 과정에서 로컬스토리지의 isLogin 을 삭제했습니다.

또한, 개발환경에서 localhost에서 cookie가 안지워져서 removeCookie 함수 수정을 했습니다.