### PR TITLE
[FE] FIX: 500에러 대응을 위한 isLogin 삭제 및 유효한 토큰 시 /home으로 리다이렉션 #90

### DIFF
--- a/src/api/baseAPI.ts
+++ b/src/api/baseAPI.ts
@@ -30,7 +30,6 @@ instance.interceptors.response.use(
       error.response?.status === STATUS_401_UNAUTHORIZED ||
       error.response?.status === undefined
     ) {
-      localStorage.removeItem("isLogin");
       removeCookie();
       clearStorage();
       window.location.href = "/";

--- a/src/api/cookie/cookies.ts
+++ b/src/api/cookie/cookies.ts
@@ -1,5 +1,4 @@
 const tokenName = import.meta.env.VITE_TOKEN;
-const domain = new URL(window.location.origin).hostname;
 
 export const getCookie = () => {
   return document.cookie
@@ -11,5 +10,6 @@ export const getCookie = () => {
 };
 
 export const removeCookie = (): void => {
+  const domain = ".24hoursarenotenough.42seoul.kr";
   document.cookie = `${tokenName}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };

--- a/src/api/cookie/cookies.ts
+++ b/src/api/cookie/cookies.ts
@@ -1,4 +1,5 @@
 const tokenName = import.meta.env.VITE_TOKEN;
+const domain = new URL(window.location.origin).hostname;
 
 export const getCookie = () => {
   return document.cookie
@@ -10,5 +11,5 @@ export const getCookie = () => {
 };
 
 export const removeCookie = (): void => {
-  document.cookie = `${tokenName}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  document.cookie = `${tokenName}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };

--- a/src/api/cookie/cookies.ts
+++ b/src/api/cookie/cookies.ts
@@ -4,12 +4,14 @@ export const getCookie = () => {
   return document.cookie
     .split(";")
     .map((cookie) => cookie.trim())
-    .filter((cookie) => tokenName === cookie.split("=")[0])
-    .join("")
-    .split("=")[1];
+    .find((cookie) => cookie.startsWith(`${tokenName}=`))
+    ?.split("=")[1];
 };
 
 export const removeCookie = (): void => {
-  const domain = ".24hoursarenotenough.42seoul.kr";
+  const hostname = window.location.hostname;
+  const domain =
+    hostname === "localhost" ? "" : ".24hoursarenotenough.42seoul.kr";
+
   document.cookie = `${tokenName}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };

--- a/src/stores/monthlog.ts
+++ b/src/stores/monthlog.ts
@@ -150,18 +150,18 @@ export const useMonthLogStore = defineStore("MonthLog", () => {
   // 달력에 보여줄 날짜 계산하기
   const calcOptions = () => {
     const options = [];
-    for (let year = FIRST_DAY.year; year <= showToday().getFullYear(); year++) {
-      if (year == FIRST_DAY.year) {
-        for (let month = FIRST_DAY.month - 1; month < 12; month++) {
-          options.push(`${year}. ${month + 1}`);
-        }
-        continue;
-      } else {
-        for (let month = 0; month <= showToday().getMonth(); month++) {
-          options.push(`${year}. ${month + 1}`);
-        }
+    const currentYear = showToday().getFullYear();
+    const currentMonth = showToday().getMonth();
+
+    for (let year = FIRST_DAY.year; year <= currentYear; year++) {
+      const startMonth = year === FIRST_DAY.year ? FIRST_DAY.month - 1 : 0;
+      const endMonth = year === currentYear ? currentMonth : 11;
+
+      for (let month = startMonth; month <= endMonth; month++) {
+        options.push(`${year}. ${month + 1}`);
       }
     }
+
     return options;
   };
 

--- a/src/views/AuthView.vue
+++ b/src/views/AuthView.vue
@@ -11,7 +11,6 @@ onMounted(() => {
   setTimeout(async () => {
     const isLogin = await getIsLogin();
     if (isLogin?.status === STATUS_204_NO_CONTENT) {
-      localStorage.setItem("isLogin", "true");
       router.push("/home");
     } else {
       router.push("/");


### PR DESCRIPTION
Closed #90 

```
{"msg":"42 인증 에러 (원인 : OAuth 토큰 만료 등)","err":{"name":"TokenError","message":"The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.","code":"invalid_grant","status":500}}
```

500에러로 뜨는 문제를 근본적으로는 해결하지 못했으나, 대응하기 위해서 웹에서 유효한 토큰을 들고 있다면 /home 으로 리다이렉션 되도록 처리합니다.
