### PR TITLE
[FE] FEAT: localstorage에 isOpen 값 저장 및 불러오기 기능 추가 #93

### DIFF
--- a/src/components/home/FoldCard.vue
+++ b/src/components/home/FoldCard.vue
@@ -4,6 +4,7 @@ import ChevronIcon from "@/components/icons/IconChevron.vue";
 import CircleProgress from "@/components/home/CircleProgress.vue";
 import LoadingAnimationVue from "@/components/common/LoadingAnimation.vue";
 import { useHomeStore } from "@/stores/home";
+import { getStorage, saveStorage } from "@/utils/localStorage";
 
 const props = defineProps<{
   hour: number;
@@ -20,7 +21,7 @@ const {
 } = useHomeStore();
 
 const isLoading = ref(getIsLoading());
-const isOpen = ref(false);
+const isOpen = ref(getStorage("isDayCardOpen") || false);
 const goalTimeSet = () => {
   if (props.isMonth) {
     return Number(getGoalMonthHour());
@@ -51,6 +52,7 @@ const culculatePercent = () => {
 
 const clickHandler = () => {
   isOpen.value = !isOpen.value;
+  saveStorage("isDayCardOpen", isOpen.value);
   if (isOpen.value) {
     colorSet.value = false;
   } else {

--- a/src/components/home/FoldCardCompact.vue
+++ b/src/components/home/FoldCardCompact.vue
@@ -3,6 +3,7 @@ import { ref, watch } from "vue";
 import ChevronIcon from "@/components/icons/IconChevron.vue";
 import LoadingAnimationVue from "@/components/common/LoadingAnimation.vue";
 import { useHomeStore } from "@/stores/home";
+import { getStorage, saveStorage } from "@/utils/localStorage";
 
 const props = defineProps<{
   hour: number;
@@ -14,7 +15,7 @@ const props = defineProps<{
 const { getIsLoading } = useHomeStore();
 const isLoading = ref(getIsLoading());
 
-const isOpen = ref(false);
+const isOpen = ref(getStorage("isMonthCardOpen") || false);
 
 watch(getIsLoading, (val) => {
   isLoading.value = val;
@@ -25,11 +26,16 @@ const checkColor = () => {
     return "#ffffff";
   }
 };
+
+const clickHandler = () => {
+  isOpen.value = !isOpen.value;
+  saveStorage("isMonthCardOpen", isOpen.value);
+};
 </script>
 
 <template>
   <div class="wrap" :class="{ on: isOpen, primaryColor: !isOpen }">
-    <div class="textWrap use tapHighlight" @click="isOpen = !isOpen">
+    <div class="textWrap use tapHighlight" @click="clickHandler">
       <h2>
         <slot name="title"></slot>
       </h2>


### PR DESCRIPTION
클릭 유무를 localstorage에 저장을 하고, 그 저장한 값을 불러와서 계속 유지될 수 있게 처리했습니다.

로그아웃 시, localstorage에 저장된 모든 값을 날리도록 미리 처리되어 있어서, 따로 값을 없애는 코드는 추가되어있지 않습니다.

Closed #93 