### PR TITLE
[FE] FIX: NA src 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,10 @@
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
-    <script type="text/javascript" src="http://wcs.naver.net/wcslog.js"></script>
+    <script
+      type="text/javascript"
+      src="https://wcs.naver.net/wcslog.js"
+    ></script>
     <script type="text/javascript">
       if (!wcs_add) var wcs_add = {};
       wcs_add["wa"] = "152eaf5cd6101c0";


### PR DESCRIPTION
Mixed Content: The page at 'https://24hoursarenotenough.42seoul.kr/home' was loaded over HTTPS, but requested an insecure script 'http://wcs.naver.net/wcslog.js'. This request has been blocked; the content must be served over HTTPS.

네이버 애널리틱스를 위한 경로중 http 를 사용하면 차단되기 때문에 https로 변경했습니다.